### PR TITLE
BUG: Bump required ITK version to avoid testing data download timeout.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT OPENSLIDE_FOUND)
 endif()
 
 if(NOT ITK_SOURCE_DIR)
-  find_package(ITK 4.9 REQUIRED)
+  find_package(ITK 4.10 REQUIRED)
   list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
   include(ITKModuleExternal)
 else()

--- a/circle.yml
+++ b/circle.yml
@@ -6,11 +6,13 @@ dependencies:
   override:
     - docker info
     - docker pull insighttoolkit/openslideio-test
-    - ~/ITKIOOpenSlide/test/Docker/build.sh
+    - ~/ITKIOOpenSlide/test/Docker/build.sh:
+        timeout: 2000
 
 test:
   override:
-    - ~/ITKIOOpenSlide/test/Docker/run.sh
+    - ~/ITKIOOpenSlide/test/Docker/run.sh:
+        timeout: 2000
 
 deployment:
   hub:

--- a/test/Docker/Dockerfile
+++ b/test/Docker/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update && apt-get install -y \
 RUN mkdir -p /usr/src/ITKOpenSlideIO-build
 WORKDIR /usr/src
 
-# 2016-04-07
-ENV ITK_GIT_TAG 399f5ea69b063a3a02376806059d8d12e8953214
+# 2016-04-14
+ENV ITK_GIT_TAG 141bf9929f73b3f928ea022ed670959e81d036ff
 RUN git clone git://itk.org/ITK.git && \
   cd ITK && \
   git checkout ${ITK_GIT_TAG} && \

--- a/test/Docker/test.sh
+++ b/test/Docker/test.sh
@@ -17,6 +17,8 @@ cmake \
     /usr/src/ITKOpenSlideIO
 ctest -VV -D Experimental
 
+mkdir -p /usr/src/ITKOpenSlideIO-example-build
+cd /usr/src/ITKOpenSlideIO-example-build
 cmake \
   -G Ninja \
   -DITK_DIR:PATH=/usr/src/ITK-build \


### PR DESCRIPTION
Update the required version of ITK to include
InsightSoftwareConsortium/ITK@92da5dd7c1ecdc517a392961b61cd0da30167899
which increases the ExternalData_TIMEOUT_ABSOLUTE. This prevents testing data
download timeouts for large testing data files.

Issue #6
