### PR TITLE
Improve streaming

### DIFF
--- a/include/itkOpenSlideImageIO.h
+++ b/include/itkOpenSlideImageIO.h
@@ -136,6 +136,27 @@ public:
 /** Returns all associated image names stored in the file. */
   virtual AssociatedImageNameContainer GetAssociatedImageNames() const;
 
+/** Returns the absolute maximum number of streamable regions (tiles). */
+  virtual int64_t ComputeMaximumNumberOfStreamableRegions() const;
+
+/** Returns the maximum number of streamable regions similar (but >=) to the given region. */
+  virtual int64_t ComputeMaximumNumberOfStreamableRegions(const ImageIORegion &clRegion) const;
+
+/** Returns the minimum streamable region. */
+  virtual ImageIORegion GetMinimumStreamableRegion() const;
+
+/** Turn on/off approximate streaming. This only affects streaming level images other than level 0. 
+  * This gives the ImageIO more flexibility with the read regions allowing for more streaming divisons
+  * at the cost of image accuracy. This flexibility is already available for level 0 whether this is 
+  * enabled or not (and does not affect accuracy).
+  * Use this if streaming results in excessive memory usage when streaming level images other than
+  * level 0.
+  */
+  virtual void SetApproximateStreaming(bool bApproximateStreaming);
+
+/** Returns whether approximate streaming is enabled or not. */
+  virtual bool GetApproximateStreaming() const;
+
 protected:
   OpenSlideImageIO();
   ~OpenSlideImageIO();

--- a/src/itkOpenSlideImageIO.cxx
+++ b/src/itkOpenSlideImageIO.cxx
@@ -96,13 +96,13 @@ public:
   OpenSlideWrapper() {
     m_Osr = NULL;
     m_Level = 0;
-    m_ApproximateImage = false;
+    m_ApproximateStreaming = false;
   }
 
   OpenSlideWrapper(const char *p_cFileName) {
     m_Osr = NULL;
     m_Level = 0;
-    m_ApproximateImage = false;
+    m_ApproximateStreaming = false;
     Open(p_cFileName);
   }
 
@@ -112,13 +112,13 @@ public:
   }
 
   // Set whether streaming should be approximate or exact
-  void SetApproximateImage(bool bApproximateImage) {
-    m_ApproximateImage = bApproximateImage;
+  void SetApproximateStreaming(bool bApproximateStreaming) {
+    m_ApproximateStreaming = bApproximateStreaming;
   }
 
   // Determine whether streaming is exact or approximate
-  bool GetApproximateImage() const {
-    return m_ApproximateImage;
+  bool GetApproximateStreaming() const {
+    return m_ApproximateStreaming;
   }
 
   // Tells the ImageIO if the wrapper is in a state where stream reading can occur.
@@ -128,7 +128,7 @@ public:
       return false;
 
     // XXX: ITK streams along X. Shouldn't we check if the minimum spacing in Y is not the size of the whole image?
-    return m_ApproximateImage || ComputeMaximumNumberOfStreamableRegions() > 1;
+    return m_ApproximateStreaming || ComputeMaximumNumberOfStreamableRegions() > 1;
   }
 
   // Closes the currently opened file
@@ -446,7 +446,7 @@ public:
     if (m_Osr == NULL)
       return false;
 
-    if (m_Level == 0 || m_ApproximateImage) // Nothing to do
+    if (m_Level == 0 || m_ApproximateStreaming) // Nothing to do
       return true;
 
     int64_t i64MinWidth = 0, i64MinHeight = 0;
@@ -484,7 +484,7 @@ private:
   openslide_t *m_Osr;
   int32_t      m_Level;
   std::string  m_AssociatedImage;
-  bool         m_ApproximateImage;
+  bool         m_ApproximateStreaming;
 };
 
 OpenSlideImageIO::OpenSlideImageIO()

--- a/src/itkOpenSlideImageIO.cxx
+++ b/src/itkOpenSlideImageIO.cxx
@@ -763,7 +763,33 @@ OpenSlideImageIO::Write( const void* /*buffer*/) {
 RequestedRegion */
 ImageIORegion
 OpenSlideImageIO::GenerateStreamableReadRegionFromRequestedRegion( const ImageIORegion & requested ) const {
-  return requested;
+  if (m_OpenSlideWrapper == NULL)
+    return requested;
+
+  ImageIORegion::SizeType clSize = requested.GetSize();
+  ImageIORegion::IndexType clStart = requested.GetIndex();
+
+  int64_t i64X = clStart[0];
+  int64_t i64Y = clStart[1];
+
+  int64_t i64Width = clSize[0];
+  int64_t i64Height = clSize[1];
+
+  if (!m_OpenSlideWrapper->AlignReadRegion(i64X, i64Y, i64Width, i64Height))
+    return requested;
+
+  clStart[0] = i64X;
+  clStart[1] = i64Y;
+
+  clSize[0] = i64Width;
+  clSize[1] = i64Height;
+
+  ImageIORegion clNewRegion(requested);
+
+  clNewRegion.SetSize(clSize);
+  clNewRegion.SetIndex(clStart);
+
+  return clNewRegion;
 }
 
 /** Get underlying OpenSlide library version */

--- a/src/itkOpenSlideImageIO.cxx
+++ b/src/itkOpenSlideImageIO.cxx
@@ -720,11 +720,11 @@ OpenSlideImageIO::GenerateStreamableReadRegionFromRequestedRegion( const ImageIO
   if (!m_OpenSlideWrapper->AlignReadRegion(i64X, i64Y, i64Width, i64Height))
     return requested;
 
-  clStart[0] = i64X;
-  clStart[1] = i64Y;
+  clStart[0] = (SizeValueType)i64X;
+  clStart[1] = (SizeValueType)i64Y;
 
-  clSize[0] = i64Width;
-  clSize[1] = i64Height;
+  clSize[0] = (SizeValueType)i64Width;
+  clSize[1] = (SizeValueType)i64Height;
 
   ImageIORegion clNewRegion(requested);
 

--- a/src/itkOpenSlideImageIO.cxx
+++ b/src/itkOpenSlideImageIO.cxx
@@ -442,6 +442,7 @@ public:
     return (i64ImageWidth + i64Width - 1)/i64Width * (i64ImageHeight + i64Height - 1)/i64Height;
   }
 
+  // Align X, Y and region dimensions to be on the grid of points invariant to upsample/downsample
   bool AlignReadRegion(int64_t &i64X, int64_t &i64Y, int64_t &i64Width, int64_t &i64Height) const {
     if (m_Osr == NULL)
       return false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,9 +36,15 @@ itk_add_test(NAME itkOpenSlideTestDownsample
 )
 
 # Compress cannot be used here since stream writing will not be supported
-itk_add_test(NAME itkOpenSlideTestStreaming
+itk_add_test(NAME itkOpenSlideTestApproximateStreaming
   COMMAND ITKIOOpenSlideTestDriver
   --compare DATA{Input/CMU-1-level-1-stream-200.mha} ${ITK_TEST_OUTPUT_DIR}/CMU-1-level-1-stream-200.mha
-  itkOpenSlideImageIOTest DATA{Input/CMU-1.svs} ${ITK_TEST_OUTPUT_DIR}/CMU-1-level-1-stream-200.mha level=1 stream=200
+  itkOpenSlideImageIOTest DATA{Input/CMU-1.svs} ${ITK_TEST_OUTPUT_DIR}/CMU-1-level-1-stream-200.mha level=1 stream=200 approximateStreaming
+)
+
+itk_add_test(NAME itkOpenSlideTestStreaming
+  COMMAND ITKIOOpenSlideTestDriver
+  --compare DATA{Input/CMU-1-level-1.mha} ${ITK_TEST_OUTPUT_DIR}/CMU-1-level-1.mha
+  itkOpenSlideImageIOTest DATA{Input/CMU-1.svs} ${ITK_TEST_OUTPUT_DIR}/CMU-1-level-1.mha level=1 stream=200
 )
 

--- a/test/itkOpenSlideImageIOTest.cxx
+++ b/test/itkOpenSlideImageIOTest.cxx
@@ -109,6 +109,7 @@ int itkOpenSlideImageIOTest( int argc, char * argv[] ) {
 
   bool bShouldFail = false;
   bool bUseCompression = false;
+  bool bApproximateStreaming = false;
   unsigned int uiNumStreams = 0; // 0 means no streaming
   int iLevel = 0;
   std::string strAssociatedImageName;
@@ -128,6 +129,9 @@ int itkOpenSlideImageIOTest( int argc, char * argv[] ) {
     }
     else if (strCommand == "compress") {
       bUseCompression = true;
+    }
+    else if (strCommand == "approximateStreaming") {
+      bApproximateStreaming = true;
     }
     else if (strCommand == "level") {
       if (strValue.empty()) {
@@ -190,6 +194,7 @@ int itkOpenSlideImageIOTest( int argc, char * argv[] ) {
   std::cout << "outputImage = '" << p_cOutputImage << '\'' << std::endl;
   std::cout << "shouldFail = " << std::boolalpha << bShouldFail << std::endl;
   std::cout << "compress = " << std::boolalpha << bUseCompression << std::endl;
+  std::cout << "approximateStreaming = " << std::boolalpha << bApproximateStreaming << std::endl;
   std::cout << "stream = " << uiNumStreams << std::endl;
   std::cout << "level = " << iLevel << std::endl;
   std::cout << "associatedImage = '" << strAssociatedImageName << '\'' << std::endl;
@@ -228,6 +233,7 @@ int itkOpenSlideImageIOTest( int argc, char * argv[] ) {
       return iFailCode;
 
     p_clImageIO->UseStreamedReadingOn();
+    p_clImageIO->SetApproximateStreaming(bApproximateStreaming);
 
     itk::ImageIOBase::Pointer p_clWriterIO = itk::ImageIOFactory::CreateImageIO(p_cOutputImage, itk::ImageIOFactory::WriteMode);
     if (!p_clWriterIO) {


### PR DESCRIPTION
This pull request adds support for streaming level images with level > 0 so that they are identical to reading the entire image all at once. It also adds some functionality for determining number of streamable regions, minimum region size and supports the old behavior through approximate streaming which can be enabled or queried at the ImageIO level. A new test was added to test both approximate and exact streaming. The data was always available but the exact version of the image (CMU-1-level.mha) was not used in testing until now.
