### PR TITLE
COMP: Use and move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkOpenSlideImageIO.h
+++ b/include/itkOpenSlideImageIO.h
@@ -52,6 +52,8 @@ class OpenSlideWrapper;
 class IOOpenSlide_EXPORT OpenSlideImageIO : public ImageIOBase
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(OpenSlideImageIO);
+
   /** Standard class typedefs. */
   typedef OpenSlideImageIO         Self;
   typedef ImageIOBase              Superclass;
@@ -164,8 +166,6 @@ protected:
   virtual void PrintSelf(std::ostream& os, Indent indent) const;
 
 private:
-  OpenSlideImageIO(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
 
   OpenSlideWrapper *m_OpenSlideWrapper; // Opaque pointer to a wrapper that manages openslide_t
 };

--- a/include/itkOpenSlideImageIOFactory.h
+++ b/include/itkOpenSlideImageIOFactory.h
@@ -35,6 +35,8 @@ namespace itk
 class IOOpenSlide_EXPORT OpenSlideImageIOFactory : public ObjectFactoryBase
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(OpenSlideImageIOFactory);
+
   /** Standard class typedefs. */
   typedef OpenSlideImageIOFactory  Self;
   typedef ObjectFactoryBase        Superclass;
@@ -62,11 +64,6 @@ public:
 protected:
   OpenSlideImageIOFactory();
   ~OpenSlideImageIOFactory();
-
-private:
-  OpenSlideImageIOFactory(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
 };
 
 } // end namespace itk


### PR DESCRIPTION
Use the `ITK_DISALLOW_COPY_AND_ASSIGN` macro to enhance consistency across
the toolkit when disallowing the copy constructor and the assign operator.

Move the `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable