### PR TITLE
STYLE: Prefer C++11 type alias over typedef.

### DIFF
--- a/examples/DumpSlideInformation.cxx
+++ b/examples/DumpSlideInformation.cxx
@@ -20,9 +20,9 @@ void Usage(const char *cArg0)
 class DumpSlideInformation
 {
 public:
-  typedef itk::RGBAPixel<unsigned char> PixelType;
-  typedef itk::Image<PixelType, 2>      ImageType;
-  typedef itk::OpenSlideImageIO         ReaderIOType;
+  using PixelType = itk::RGBAPixel<unsigned char>;
+  using ImageType = itk::Image<PixelType, 2>;
+  using ReaderIOType = itk::OpenSlideImageIO;
 
   DumpSlideInformation()
   {
@@ -307,8 +307,8 @@ bool
 DumpSlideInformation
 ::WriteImage(const char *fileName) const
 {
-  typedef itk::ImageFileReader<ImageType> ReaderType;
-  typedef itk::ImageFileWriter<ImageType> WriterType;
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  using WriterType = itk::ImageFileWriter<ImageType>;
 
   ReaderType::Pointer clReader = ReaderType::New();
 

--- a/include/itkOpenSlideImageIO.h
+++ b/include/itkOpenSlideImageIO.h
@@ -54,11 +54,11 @@ class IOOpenSlide_EXPORT OpenSlideImageIO : public ImageIOBase
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(OpenSlideImageIO);
 
-  /** Standard class typedefs. */
-  typedef OpenSlideImageIO         Self;
-  typedef ImageIOBase              Superclass;
-  typedef SmartPointer<Self>       Pointer;
-  typedef std::vector<std::string> AssociatedImageNameContainer;
+  /** Standard class type alias. */
+  using Self = OpenSlideImageIO;
+  using Superclass = ImageIOBase;
+  using Pointer = SmartPointer<Self>;
+  using AssociatedImageNameContainer = std::vector<std::string>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
@@ -66,7 +66,7 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(OpenSlideImageIO, ImageIOBase);
 
-  typedef Superclass::ArrayOfExtensionsType ArrayOfExtensionsType;
+  using ArrayOfExtensionsType = Superclass::ArrayOfExtensionsType;
 
  /*-------- This part of the interfaces deals with reading data. ----- */
 

--- a/include/itkOpenSlideImageIOFactory.h
+++ b/include/itkOpenSlideImageIOFactory.h
@@ -37,11 +37,11 @@ class IOOpenSlide_EXPORT OpenSlideImageIOFactory : public ObjectFactoryBase
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(OpenSlideImageIOFactory);
 
-  /** Standard class typedefs. */
-  typedef OpenSlideImageIOFactory  Self;
-  typedef ObjectFactoryBase        Superclass;
-  typedef SmartPointer<Self>       Pointer;
-  typedef SmartPointer<const Self> ConstPointer;
+  /** Standard class type alias. */
+  using Self = OpenSlideImageIOFactory;
+  using Superclass = ObjectFactoryBase;
+  using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Class methods used to interface with the registered factories. */
   virtual const char* GetITKSourceVersion() const;

--- a/src/itkOpenSlideImageIO.cxx
+++ b/src/itkOpenSlideImageIO.cxx
@@ -490,7 +490,7 @@ private:
 
 OpenSlideImageIO::OpenSlideImageIO()
 {
-  typedef RGBAPixel<unsigned char> PixelType;
+  using PixelType = RGBAPixel<unsigned char>;
   PixelType clPixel;
 
   m_OpenSlideWrapper = NULL;
@@ -564,7 +564,7 @@ bool OpenSlideImageIO::CanStreamRead() {
 }
 
 void OpenSlideImageIO::ReadImageInformation() {
-  typedef RGBAPixel<unsigned char> PixelType;
+  using PixelType = RGBAPixel<unsigned char>;
   PixelType clPixel;
 
   this->SetNumberOfDimensions(2);

--- a/test/itkOpenSlideImageIOTest.cxx
+++ b/test/itkOpenSlideImageIOTest.cxx
@@ -60,11 +60,11 @@ bool ParseValue(const char *p_cValue, std::string &strCommand, std::string &strV
 #if 0
 // For generating data for tests (particularly the streaming one)
 bool CompressImageFile(const char *p_cFileName) {
-  typedef itk::RGBAPixel<unsigned char> PixelType;
-  typedef itk::Image<PixelType, 2>      ImageType;
+  using PixelType = itk::RGBAPixel<unsigned char>;
+  using ImageType = itk::Image<PixelType, 2>;
 
-  typedef itk::ImageFileReader<ImageType> ReaderType;
-  typedef itk::ImageFileWriter<ImageType> WriterType;
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  using WriterType = itk::ImageFileWriter<ImageType>;
 
   ReaderType::Pointer p_clReader = ReaderType::New();
   WriterType::Pointer p_clWriter = WriterType::New();
@@ -89,11 +89,11 @@ bool CompressImageFile(const char *p_cFileName) {
 } // End anonymous namespace
 
 int itkOpenSlideImageIOTest( int argc, char * argv[] ) {
-  typedef itk::RGBAPixel<unsigned char>   PixelType;
-  typedef itk::Image<PixelType, 2>        ImageType;
-  typedef itk::OpenSlideImageIO           ReaderIOType;
-  typedef itk::ImageFileReader<ImageType> ReaderType;
-  typedef itk::ImageFileWriter<ImageType> WriterType;
+  using PixelType = itk::RGBAPixel<unsigned char>;
+  using ImageType = itk::Image<PixelType, 2>;
+  using ReaderIOType = itk::OpenSlideImageIO;
+  using ReaderType = itk::ImageFileReader<ImageType>;
+  using WriterType = itk::ImageFileWriter<ImageType>;
 
   if( argc < 3 ) {
     std::cerr << "Usage: " << argv[0] << " inputImage outputImage [command1 command2 ...]\n";

--- a/test/itkOpenSlideTestMetaData.cxx
+++ b/test/itkOpenSlideTestMetaData.cxx
@@ -76,11 +76,11 @@ bool ReadFileStripCR(const char *p_cFileName, std::vector<char> &vBuffer) {
 } // End anonymous namespace
 
 int itkOpenSlideTestMetaData( int argc, char * argv[] ) {
-  typedef itk::OpenSlideImageIO         ImageIOType;
-  typedef itk::RGBAPixel<unsigned char> PixelType;
-  typedef itk::Image<PixelType, 2>      ImageType;
-  typedef ImageType::SizeType           SizeType;
-  typedef ImageType::SpacingType        SpacingType;
+  using ImageIOType = itk::OpenSlideImageIO;
+  using PixelType = itk::RGBAPixel<unsigned char>;
+  using ImageType = itk::Image<PixelType, 2>;
+  using SizeType = ImageType::SizeType;
+  using SpacingType = ImageType::SpacingType;
 
   if (argc < 2 || argc > 4) {
     std::cerr << "Usage: " << argv[0] << " slideFile [outputLog] [comparisonLog]" << std::endl;


### PR DESCRIPTION
Prefer C++11 type alias over typedef for the reasons stated here:
http://review.source.kitware.com/#/c/23103/