### PR TITLE
ENH: Allow building examples.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,3 +15,5 @@ if(NOT ITK_SOURCE_DIR)
 else()
   itk_module_impl()
 endif()
+
+itk_module_examples()


### PR DESCRIPTION
Use the ITK CMake macros to build the examples module.