### PR TITLE
ENH: Remove unnecessary, unused CMake variable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.10.2)
 project(IOOpenSlide)
-set(IOOpenSlide_LIBRARIES IOOpenSlide)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 find_package( OpenSlide REQUIRED )


### PR DESCRIPTION
Remove unnecessary, unused CMake `IOOpenSlide_LIBRARIES ` variable.