### PR TITLE
COMP: Change to enum to new enum class definitions

### DIFF
--- a/test/itkOpenSlideImageIOTest.cxx
+++ b/test/itkOpenSlideImageIOTest.cxx
@@ -235,7 +235,7 @@ int itkOpenSlideImageIOTest( int argc, char * argv[] ) {
     p_clImageIO->UseStreamedReadingOn();
     p_clImageIO->SetApproximateStreaming(bApproximateStreaming);
 
-    itk::ImageIOBase::Pointer p_clWriterIO = itk::ImageIOFactory::CreateImageIO(p_cOutputImage, itk::ImageIOFactory::WriteMode);
+    itk::ImageIOBase::Pointer p_clWriterIO = itk::ImageIOFactory::CreateImageIO(p_cOutputImage, itk::ImageIOFactory::FileModeType::WriteMode);
     if (!p_clWriterIO) {
       std::cerr << "Error: Could not create ImageIO for output image '" << p_cOutputImage << "'." << std::endl;
       return iFailCode;


### PR DESCRIPTION
When ITK is configured with the following:

- ITK_LEGACY_REMOVE = ON

- ITK_FUTURE_LEGACY_REMOVE = ON

- ITK_LEGACY_SILENT = OFF

- Module_IOOpenSlide = ON

Build errors occur with references to older 'C' style enums. The following changes incorporate the new enum class: FileModeType and resolves such errors.

Co-Authored-By: Hans Johnson hans-johnson@uiowa.edu