### PR TITLE
Update module for clean ITK build

### DIFF
--- a/include/itkOpenSlideImageIO.h
+++ b/include/itkOpenSlideImageIO.h
@@ -52,7 +52,7 @@ class OpenSlideWrapper;
 class IOOpenSlide_EXPORT OpenSlideImageIO : public ImageIOBase
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(OpenSlideImageIO);
+  ITK_DISALLOW_COPY_AND_MOVE(OpenSlideImageIO);
 
   /** Standard class type alias. */
   using Self = OpenSlideImageIO;

--- a/include/itkOpenSlideImageIOFactory.h
+++ b/include/itkOpenSlideImageIOFactory.h
@@ -35,7 +35,7 @@ namespace itk
 class IOOpenSlide_EXPORT OpenSlideImageIOFactory : public ObjectFactoryBase
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(OpenSlideImageIOFactory);
+  ITK_DISALLOW_COPY_AND_MOVE(OpenSlideImageIOFactory);
 
   /** Standard class type alias. */
   using Self = OpenSlideImageIOFactory;

--- a/test/itkOpenSlideImageIOTest.cxx
+++ b/test/itkOpenSlideImageIOTest.cxx
@@ -235,7 +235,7 @@ int itkOpenSlideImageIOTest( int argc, char * argv[] ) {
     p_clImageIO->UseStreamedReadingOn();
     p_clImageIO->SetApproximateStreaming(bApproximateStreaming);
 
-    itk::ImageIOBase::Pointer p_clWriterIO = itk::ImageIOFactory::CreateImageIO(p_cOutputImage, itk::ImageIOFactory::FileModeType::WriteMode);
+    itk::ImageIOBase::Pointer p_clWriterIO = itk::ImageIOFactory::CreateImageIO(p_cOutputImage, itk::IOFileModeEnum::WriteMode);
     if (!p_clWriterIO) {
       std::cerr << "Error: Could not create ImageIO for output image '" << p_cOutputImage << "'." << std::endl;
       return iFailCode;


### PR DESCRIPTION
## Description
This module has not been updated with changes made to ITK for some time. In order for the latest `master` for ITK to build cleanly, the following changes were made.

#### Changes
- Changes `ITK_DISALLOW_COPY_AND_ASSIGN` to `ITK_DISALLOW_COPY_AND_MOVE`
- Specify correct enumeration path for `itk::IOFileModeEnum::WriteMode`