### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,318 @@
+## This config file is only relevant for clang-format version 19.1.4
+##
+## Examples of each format style can be found on the in the clang-format documentation
+## See: https://clang.llvm.org/docs/ClangFormatStyleOptions.html for details of each option
+##
+## The clang-format binaries can be downloaded as part of the clang binary distributions
+## from https://releases.llvm.org/download.html
+##
+## Use the script Utilities/Maintenance/clang-format.bash to faciliate
+## maintaining a consistent code style.
+##
+## EXAMPLE apply code style enforcement before commit:
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_19.1.4} --modified
+## EXAMPLE apply code style enforcement after commit:
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_19.1.4} --last
+---
+# This configuration requires clang-format version 19.1.4 exactly.
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseArrows: false
+  AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseExpressionOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+#AllowShortFunctionsOnASingleLine: Inline Only merge functions defined inside a class. Implies empty.
+#AllowShortFunctionsOnASingleLine: None (in configuration: None) Never merge functions into a single line.
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AttributeMacros:
+  - __capability
+BinPackArguments: false
+BinPackParameters: false
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterExternBlock: true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
+BreakAfterJavaFieldAnnotations: false
+BreakAfterReturnType: All
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: BeforeComma
+BreakStringLiterals: true
+BreakTemplateDeclarations: Yes
+## The following line allows larger lines in non-documentation code
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: AfterHash
+IndentRequiresClause: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLines:
+  AtEndOfFile:     false
+  AtStartOfBlock:  true
+  AtStartOfFile:   true
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MainIncludeChar: Quote
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+## The following line allows larger lines in non-documentation code
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Middle
+PPIndentWidth:   -1
+QualifierAlignment: Custom
+QualifierOrder:
+  - friend
+  - static
+  - inline
+  - constexpr
+  - const
+  - type
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
+# We may want to sort the includes as a separate pass
+SortIncludes:    Never
+SortJavaStaticImport: Before
+# We may want to revisit this later
+SortUsingDeclarations: Never
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInContainerLiterals: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+  - ITK_GCC_PRAGMA_PUSH
+  - ITK_GCC_PRAGMA_POP
+  - ITK_GCC_SUPPRESS_Wfloat_equal
+  - ITK_GCC_SUPPRESS_Wformat_nonliteral
+  - ITK_GCC_SUPPRESS_Warray_bounds
+  - ITK_CLANG_PRAGMA_PUSH
+  - ITK_CLANG_PRAGMA_POP
+  - ITK_CLANG_SUPPRESS_Wzero_as_null_pointer_constant
+  - CLANG_PRAGMA_PUSH
+  - CLANG_PRAGMA_POP
+  - CLANG_SUPPRESS_Wfloat_equal
+  - INTEL_PRAGMA_WARN_PUSH
+  - INTEL_PRAGMA_WARN_POP
+  - INTEL_SUPPRESS_warning_1292
+  - itkTemplateFloatingToIntegerMacro
+  - itkLegacyMacro
+TableGenBreakInsideDAGArg: DontBreak
+TabWidth:        2
+UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+...

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -12,9 +12,9 @@ on:
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.2
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.2
     secrets:
       pypi_password: ${{ secrets.pypi_password }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16.3)
 project(IOOpenSlide)
 set(IOOpenSlide_LIBRARIES IOOpenSlide)
 

--- a/examples/DumpSlideInformation.cxx
+++ b/examples/DumpSlideInformation.cxx
@@ -10,7 +10,8 @@
 #include "itkRGBAPixel.h"
 #include "itkMetaDataObject.h"
 
-void Usage(const char *cArg0)
+void
+Usage(const char * cArg0)
 {
   std::cerr << "Usage: " << cArg0 << " slideFile" << std::endl;
   exit(1);
@@ -24,45 +25,49 @@ public:
   using ImageType = itk::Image<PixelType, 2>;
   using ReaderIOType = itk::OpenSlideImageIO;
 
-  DumpSlideInformation()
-  {
-    m_CLReaderIO = ReaderIOType::New();
-  }
+  DumpSlideInformation() { m_CLReaderIO = ReaderIOType::New(); }
 
   // Don't try to load an image larger than this size
-  size_t MaxImageSizeInBytes() const
+  size_t
+  MaxImageSizeInBytes() const
   {
     return (size_t)1024 * 1024 * 100;
   }
 
-  void SetFileName(const std::string & fileName)
+  void
+  SetFileName(const std::string & fileName)
   {
     m_CLReaderIO->SetFileName(fileName);
   }
 
-  bool DumpInformation() const;
-  bool WriteLevels() const;
-  bool WriteAssociatedImages() const;
+  bool
+  DumpInformation() const;
+  bool
+  WriteLevels() const;
+  bool
+  WriteAssociatedImages() const;
 
 private:
   ReaderIOType::Pointer m_CLReaderIO;
 
-  bool ReadImageInformation() const
+  bool
+  ReadImageInformation() const
   {
     try
-      {
+    {
       m_CLReaderIO->ReadImageInformation();
-      }
+    }
     catch (itk::ExceptionObject & e)
-      {
+    {
       std::cerr << "Error: " << e << std::endl;
       return false;
-      }
+    }
 
     return true;
   }
 
-  ImageType::SizeType GetSize() const
+  ImageType::SizeType
+  GetSize() const
   {
     ImageType::SizeType clSize;
     clSize[0] = m_CLReaderIO->GetDimensions(0);
@@ -70,7 +75,8 @@ private:
     return clSize;
   }
 
-  ImageType::SpacingType GetSpacing() const
+  ImageType::SpacingType
+  GetSpacing() const
   {
     ImageType::SpacingType clSpacing;
     clSpacing[0] = m_CLReaderIO->GetSpacing(0);
@@ -78,23 +84,29 @@ private:
     return clSpacing;
   }
 
-  bool DumpImageInformation() const;
-  bool DumpMetaData() const;
-  bool DumpLevelInformation() const;
-  bool DumpAssociatedImageInformation() const;
+  bool
+  DumpImageInformation() const;
+  bool
+  DumpMetaData() const;
+  bool
+  DumpLevelInformation() const;
+  bool
+  DumpAssociatedImageInformation() const;
 
-  bool WriteImage(const char * fileName) const;
+  bool
+  WriteImage(const char * fileName) const;
 };
 
 
-int main(int argc, char **argv)
+int
+main(int argc, char ** argv)
 {
   const char * const cArg0 = argv[0];
   if (argc != 2)
-    {
+  {
     Usage(cArg0);
     return EXIT_FAILURE;
-    }
+  }
 
   std::string slideImage = argv[1];
 
@@ -102,29 +114,29 @@ int main(int argc, char **argv)
   clInfo.SetFileName(slideImage);
 
   if (!clInfo.DumpInformation() || !clInfo.WriteLevels() || !clInfo.WriteAssociatedImages())
-    {
+  {
     return EXIT_FAILURE;
-    }
+  }
 
   return EXIT_SUCCESS;
 }
 
 
 bool
-DumpSlideInformation
-::DumpInformation() const
+DumpSlideInformation ::DumpInformation() const
 {
-  return ReadImageInformation() && DumpImageInformation() && DumpMetaData() && DumpLevelInformation() && DumpAssociatedImageInformation();
+  return ReadImageInformation() && DumpImageInformation() && DumpMetaData() && DumpLevelInformation() &&
+         DumpAssociatedImageInformation();
 }
 
 
 bool
-DumpSlideInformation
-::DumpImageInformation() const
+DumpSlideInformation ::DumpImageInformation() const
 {
   std::cout << "\nImage Information:\n" << std::endl;
   std::cout << "Dimensions: " << m_CLReaderIO->GetNumberOfDimensions() << std::endl;
-  std::cout << "Component type: " << itk::ImageIOBase::GetComponentTypeAsString(m_CLReaderIO->GetComponentType()) << std::endl;
+  std::cout << "Component type: " << itk::ImageIOBase::GetComponentTypeAsString(m_CLReaderIO->GetComponentType())
+            << std::endl;
   std::cout << "Pixel type: " << itk::ImageIOBase::GetPixelTypeAsString(m_CLReaderIO->GetPixelType()) << std::endl;
   std::cout << "Vendor: " << m_CLReaderIO->GetVendor() << std::endl;
 
@@ -133,34 +145,32 @@ DumpSlideInformation
 
 
 bool
-DumpSlideInformation
-::DumpMetaData() const
+DumpSlideInformation ::DumpMetaData() const
 {
   std::cout << "\nMeta Data:\n" << std::endl;
 
-  itk::MetaDataDictionary &clTags = m_CLReaderIO->GetMetaDataDictionary();
-  std::vector<std::string> keys = clTags.GetKeys();
+  itk::MetaDataDictionary & clTags = m_CLReaderIO->GetMetaDataDictionary();
+  std::vector<std::string>  keys = clTags.GetKeys();
 
   std::cout << "Number of keys: " << keys.size() << std::endl;
   std::cout << "Entries:" << std::endl;
   for (size_t i = 0; i < keys.size(); ++i)
-    {
+  {
     const std::string & key = keys[i];
-    std::string value;
+    std::string         value;
 
     if (itk::ExposeMetaData(clTags, key, value))
-      {
+    {
       std::cout << key << " = " << value << std::endl;
-      }
     }
+  }
 
   return true;
 }
 
 
 bool
-DumpSlideInformation
-::DumpLevelInformation() const
+DumpSlideInformation ::DumpLevelInformation() const
 {
   std::cout << "\nLevel Information:\n" << std::endl;
 
@@ -169,24 +179,24 @@ DumpSlideInformation
 
   std::cout << "Levels:" << std::endl;
   for (int level = 0; level < levelCount; ++level)
-    {
+  {
     m_CLReaderIO->SetLevel(level);
 
     if (!ReadImageInformation())
-      {
+    {
       return false;
-      }
-
-    std::cout << "Level " << level << ": dimensions = " << GetSize() << ", spacing = " << GetSpacing() << ", size in bytes = " << m_CLReaderIO->GetImageSizeInBytes() << std::endl;
     }
+
+    std::cout << "Level " << level << ": dimensions = " << GetSize() << ", spacing = " << GetSpacing()
+              << ", size in bytes = " << m_CLReaderIO->GetImageSizeInBytes() << std::endl;
+  }
 
   return true;
 }
 
 
 bool
-DumpSlideInformation
-::DumpAssociatedImageInformation() const
+DumpSlideInformation ::DumpAssociatedImageInformation() const
 {
   std::cout << "\nAssociated image information:\n" << std::endl;
 
@@ -198,43 +208,43 @@ DumpSlideInformation
   const size_t numWordsPerLine = 3;
 
   for (size_t i = 0; i < associatedImages.size(); i += numWordsPerLine)
-    {
+  {
     const size_t jBegin = i;
     const size_t jEnd = std::min(associatedImages.size(), jBegin + numWordsPerLine);
 
     std::cout << '\'' << associatedImages[jBegin] << '\'';
 
-    for (size_t j = jBegin+1; j < jEnd; ++j)
-      {
+    for (size_t j = jBegin + 1; j < jEnd; ++j)
+    {
       std::cout << ", '" << associatedImages[j] << '\'';
-      }
+    }
 
     std::cout << std::endl;
-    }
+  }
 
   std::cout << "\nAssociated images:" << std::endl;
 
   for (size_t i = 0; i < associatedImages.size(); ++i)
-    {
-    const std::string &associatedImage = associatedImages[i];
+  {
+    const std::string & associatedImage = associatedImages[i];
 
     m_CLReaderIO->SetAssociatedImageName(associatedImage);
 
     if (!this->ReadImageInformation())
-      {
+    {
       return false;
-      }
-
-    std::cout << associatedImage << ": dimensions = " << GetSize() << ", spacing = " << GetSpacing() << ", size in bytes = " << m_CLReaderIO->GetImageSizeInBytes() << std::endl;
     }
+
+    std::cout << associatedImage << ": dimensions = " << GetSize() << ", spacing = " << GetSpacing()
+              << ", size in bytes = " << m_CLReaderIO->GetImageSizeInBytes() << std::endl;
+  }
 
   return true;
 }
 
 
 bool
-DumpSlideInformation
-::WriteLevels() const
+DumpSlideInformation ::WriteLevels() const
 {
   std::cout << "\nWriting level images to file ...\n" << std::endl;
 
@@ -242,13 +252,15 @@ DumpSlideInformation
 
   std::stringstream nameStream;
 
-  for (int iLevel = 0; iLevel < iLevelCount; ++iLevel) {
+  for (int iLevel = 0; iLevel < iLevelCount; ++iLevel)
+  {
     m_CLReaderIO->SetLevel(iLevel);
 
     if (!ReadImageInformation())
       return false;
 
-    if (m_CLReaderIO->GetImageSizeInBytes() > MaxImageSizeInBytes()) {
+    if (m_CLReaderIO->GetImageSizeInBytes() > MaxImageSizeInBytes())
+    {
       std::cout << "Level " << iLevel << " image is too large. Skipping." << std::endl;
       continue;
     }
@@ -268,29 +280,28 @@ DumpSlideInformation
 
 
 bool
-DumpSlideInformation
-::WriteAssociatedImages() const
+DumpSlideInformation ::WriteAssociatedImages() const
 {
   std::cout << "\nWriting associated images to file ...\n" << std::endl;
 
   ReaderIOType::AssociatedImageNameContainer associatedImages = m_CLReaderIO->GetAssociatedImageNames();
 
   for (size_t i = 0; i < associatedImages.size(); ++i)
-    {
+  {
     const std::string & associatedImage = associatedImages[i];
 
     m_CLReaderIO->SetAssociatedImageName(associatedImage);
 
     if (!this->ReadImageInformation())
-      {
+    {
       return false;
-      }
+    }
 
     if (m_CLReaderIO->GetImageSizeInBytes() > MaxImageSizeInBytes())
-      {
+    {
       std::cout << "Associated image '" << associatedImage << "' is too large. Skipping." << std::endl;
       continue;
-      }
+    }
 
     std::string fileName = associatedImage + ".tiff";
 
@@ -304,8 +315,7 @@ DumpSlideInformation
 
 
 bool
-DumpSlideInformation
-::WriteImage(const char *fileName) const
+DumpSlideInformation ::WriteImage(const char * fileName) const
 {
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
@@ -322,14 +332,14 @@ DumpSlideInformation
   clWriter->SetFileName(fileName);
 
   try
-    {
+  {
     clWriter->Update();
-    }
+  }
   catch (itk::ExceptionObject & e)
-    {
+  {
     std::cerr << "Error: " << e << std::endl;
     return false;
-    }
+  }
 
   return true;
 }

--- a/include/itkOpenSlideImageIO.h
+++ b/include/itkOpenSlideImageIO.h
@@ -64,7 +64,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(OpenSlideImageIO, ImageIOBase);
+  itkOverrideGetNameOfClassMacro(OpenSlideImageIO);
 
   using ArrayOfExtensionsType = Superclass::ArrayOfExtensionsType;
 

--- a/include/itkOpenSlideImageIOFactory.h
+++ b/include/itkOpenSlideImageIOFactory.h
@@ -52,7 +52,7 @@ public:
   static OpenSlideImageIOFactory* FactoryNew() { return new OpenSlideImageIOFactory;}
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(OpenSlideImageIOFactory, ObjectFactoryBase);
+  itkOverrideGetNameOfClassMacro(OpenSlideImageIOFactory);
 
   /** Register one factory of this type  */
   static void RegisterOneFactory()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "itk-ioopenslide"
-version = "1.0.0"
+version = "1.0.1"
 description = "ImageIO for the OpenSlide library supported file formats."
 readme = "README.rst"
 license = {file = "LICENSE"}
@@ -37,7 +37,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "itk == 5.4.*",
 ]

--- a/src/itkOpenSlideImageIO.cxx
+++ b/src/itkOpenSlideImageIO.cxx
@@ -34,16 +34,19 @@ namespace itk
 
 // OpenSlide wrapper class
 // This is responsible for freeing the OpenSlide context on destruction
-// It also allows for seamless access to various levels and associated images through one set of functions (as opposed to two)
-class OpenSlideWrapper {
+// It also allows for seamless access to various levels and associated images through one set of functions (as opposed
+// to two)
+class OpenSlideWrapper
+{
 public:
-
-  // GCD Algorithm from wikipedia pseudo code: 
+  // GCD Algorithm from wikipedia pseudo code:
   // https://en.wikipedia.org/wiki/Greatest_common_divisor#Binary_method
-  // 
+  //
   // NOTE: While vnl_rational can do this too, vnl_rational is defined for long integers (32 bit integers on amd64).
   //       Slides can be extremely large. It would ideal to work with 64 bit integers.
-  static uint64_t GCD(uint64_t ui64A, uint64_t ui64B) {
+  static uint64_t
+  GCD(uint64_t ui64A, uint64_t ui64B)
+  {
     if (ui64A == 0)
       return ui64B;
 
@@ -57,13 +60,15 @@ public:
       return ui64A;
 
     unsigned int uiExp = 0;
-    while ((ui64A & 1) == 0 && (ui64B & 1) == 0) {
+    while ((ui64A & 1) == 0 && (ui64B & 1) == 0)
+    {
       ui64A >>= 1;
       ui64B >>= 1;
       ++uiExp;
     }
 
-    while (ui64A != ui64B) {
+    while (ui64A != ui64B)
+    {
       if ((ui64A & 1) == 0)
         ui64A >>= 1;
       else if ((ui64B & 1) == 0)
@@ -78,28 +83,36 @@ public:
   }
 
   // Detects the vendor. Should return NULL if the file is not readable.
-  static const char * DetectVendor(const char *p_cFileName) {
+  static const char *
+  DetectVendor(const char * p_cFileName)
+  {
     return openslide_detect_vendor(p_cFileName);
   }
 
   // Weak check if the file can be read
-  static bool CanReadFile(const char *p_cFileName) {
+  static bool
+  CanReadFile(const char * p_cFileName)
+  {
     return DetectVendor(p_cFileName) != NULL;
   }
 
   // Returns version of OpenSlide library
-  static const char * GetVersion() {
+  static const char *
+  GetVersion()
+  {
     return openslide_get_version();
   }
 
   // Constructors
-  OpenSlideWrapper() {
+  OpenSlideWrapper()
+  {
     m_Osr = NULL;
     m_Level = 0;
     m_ApproximateStreaming = false;
   }
 
-  OpenSlideWrapper(const char *p_cFileName) {
+  OpenSlideWrapper(const char * p_cFileName)
+  {
     m_Osr = NULL;
     m_Level = 0;
     m_ApproximateStreaming = false;
@@ -107,23 +120,27 @@ public:
   }
 
   // Destructor
-  ~OpenSlideWrapper() {
-    Close();
-  }
+  ~OpenSlideWrapper() { Close(); }
 
   // Set whether streaming should be approximate or exact
-  void SetApproximateStreaming(bool bApproximateStreaming) {
+  void
+  SetApproximateStreaming(bool bApproximateStreaming)
+  {
     m_ApproximateStreaming = bApproximateStreaming;
   }
 
   // Determine whether streaming is exact or approximate
-  bool GetApproximateStreaming() const {
+  bool
+  GetApproximateStreaming() const
+  {
     return m_ApproximateStreaming;
   }
 
   // Tells the ImageIO if the wrapper is in a state where stream reading can occur.
   // While OpenSlide supports reading regions of level images, it does not for associated images.
-  bool CanStreamRead() const {
+  bool
+  CanStreamRead() const
+  {
     if (m_AssociatedImage.size() > 0)
       return false;
 
@@ -132,27 +149,36 @@ public:
   }
 
   // Closes the currently opened file
-  void Close() {
-    if (m_Osr != NULL) {
+  void
+  Close()
+  {
+    if (m_Osr != NULL)
+    {
       openslide_close(m_Osr);
       m_Osr = NULL;
     }
   }
 
   // Checks weather a slide file is currently opened
-  bool IsOpened() const {
+  bool
+  IsOpened() const
+  {
     return m_Osr != NULL;
   }
 
   // Opens a slide file
-  bool Open(const char *p_cFileName) {
+  bool
+  Open(const char * p_cFileName)
+  {
     Close();
     m_Osr = openslide_open(p_cFileName);
     return m_Osr != NULL;
   }
 
   // Get error string, NULL if there is no error
-  const char * GetError() const {
+  const char *
+  GetError() const
+  {
     if (m_Osr == NULL)
       return "OpenSlideWrapper has no file open.";
 
@@ -161,29 +187,39 @@ public:
 
   // Sets the level that is accessible with ReadRegion, GetDimensions, GetSpacing.
   // Clears any associated image context.
-  void SetLevel(int32_t i32Level) {
+  void
+  SetLevel(int32_t i32Level)
+  {
     m_Level = i32Level;
     m_AssociatedImage.clear();
   }
 
   // Returns the currently selected level
-  int32_t GetLevel() const {
+  int32_t
+  GetLevel() const
+  {
     return m_Level;
   }
 
   // Sets the associated image that is accessible with ReadRegion, GetDimensions
-  void SetAssociatedImageName(const std::string &strImageName) {
+  void
+  SetAssociatedImageName(const std::string & strImageName)
+  {
     m_AssociatedImage = strImageName;
     m_Level = 0;
   }
 
   // Returns the currently selected associated image
-  const std::string & GetAssociatedImageName() const {
+  const std::string &
+  GetAssociatedImageName() const
+  {
     return m_AssociatedImage;
   }
 
   // Given a downsample factor, uses OpenSlide to determine the best level to use.
-  bool SetBestLevelForDownsample(double dDownsample) {
+  bool
+  SetBestLevelForDownsample(double dDownsample)
+  {
     if (m_Osr == NULL)
       return false;
 
@@ -198,7 +234,9 @@ public:
   }
 
   // Returns the number of levels in this file
-  int32_t GetLevelCount() const {
+  int32_t
+  GetLevelCount() const
+  {
     if (m_Osr == NULL)
       return -1;
 
@@ -207,14 +245,18 @@ public:
 
   // Returns NULL for success
   // NOTE: When reading associated images, x, y, width and height are ignored.
-  const char * ReadRegion(uint32_t *p_ui32Dest, int64_t i64X, int64_t i64Y, int64_t i64Width, int64_t i64Height) const {
+  const char *
+  ReadRegion(uint32_t * p_ui32Dest, int64_t i64X, int64_t i64Y, int64_t i64Width, int64_t i64Height) const
+  {
     if (m_Osr == NULL)
       return "OpenSlideWrapper has no file open.";
 
-    if (m_AssociatedImage.size() > 0) {
+    if (m_AssociatedImage.size() > 0)
+    {
       openslide_read_associated_image(m_Osr, m_AssociatedImage.c_str(), p_ui32Dest);
     }
-    else {
+    else
+    {
       const double dDownsampleFactor = openslide_get_level_downsample(m_Osr, m_Level);
 
       if (dDownsampleFactor <= 0.0)
@@ -233,8 +275,11 @@ public:
   }
 
   // Computes the spacing depending on selected level
-  // Default spacing is relative to 1 MPP if the function fails to detect spacing information (downsample factor is considered)
-  bool GetSpacing(double &dSpacingX, double &dSpacingY) const {
+  // Default spacing is relative to 1 MPP if the function fails to detect spacing information (downsample factor is
+  // considered)
+  bool
+  GetSpacing(double & dSpacingX, double & dSpacingY) const
+  {
     dSpacingX = dSpacingY = 1.0;
 
     if (m_Osr == NULL)
@@ -248,7 +293,9 @@ public:
     if (dDownsample <= 0.0)
       return false;
 
-    if (!GetPropertyValue(OPENSLIDE_PROPERTY_NAME_MPP_X, dSpacingX) || !GetPropertyValue(OPENSLIDE_PROPERTY_NAME_MPP_Y, dSpacingY)) {
+    if (!GetPropertyValue(OPENSLIDE_PROPERTY_NAME_MPP_X, dSpacingX) ||
+        !GetPropertyValue(OPENSLIDE_PROPERTY_NAME_MPP_Y, dSpacingY))
+    {
       dSpacingX = dSpacingY = dDownsample;
       return false;
     }
@@ -260,7 +307,9 @@ public:
   }
 
   // Returns the dimension of the level or associated image
-  bool GetDimensions(int64_t &i64Width, int64_t &i64Height) const {
+  bool
+  GetDimensions(int64_t & i64Width, int64_t & i64Height) const
+  {
     i64Width = i64Height = 0;
 
     if (m_Osr == NULL)
@@ -275,7 +324,9 @@ public:
   }
 
   // Retrieves associated image names from the open slide and places them into a std::vector
-  std::vector<std::string> GetAssociatedImageNames() const {
+  std::vector<std::string>
+  GetAssociatedImageNames() const
+  {
     if (m_Osr == NULL)
       return std::vector<std::string>();
 
@@ -283,7 +334,7 @@ public:
 
     if (p_cNames == NULL)
       return std::vector<std::string>();
-  
+
     std::vector<std::string> vNames;
 
     for (int i = 0; p_cNames[i] != NULL; ++i)
@@ -293,7 +344,9 @@ public:
   }
 
   // Forms an ITK MetaDataDictionary
-  MetaDataDictionary GetMetaDataDictionary() const {
+  MetaDataDictionary
+  GetMetaDataDictionary() const
+  {
     if (m_Osr == NULL)
       return MetaDataDictionary();
 
@@ -301,10 +354,12 @@ public:
 
     const char * const * p_cNames = openslide_get_property_names(m_Osr);
 
-    if (p_cNames != NULL) {
+    if (p_cNames != NULL)
+    {
       std::string strValue;
 
-      for (int i = 0; p_cNames[i] != NULL; ++i) {
+      for (int i = 0; p_cNames[i] != NULL; ++i)
+      {
         strValue.clear();
 
         if (GetPropertyValue(p_cNames[i], strValue))
@@ -316,8 +371,10 @@ public:
   }
 
   // Templated functions for accessing and casting property values
-  template<typename ValueType>
-  bool GetPropertyValue(const char *p_cKey, ValueType &value) const {
+  template <typename ValueType>
+  bool
+  GetPropertyValue(const char * p_cKey, ValueType & value) const
+  {
     if (m_Osr == NULL)
       return false;
 
@@ -333,7 +390,9 @@ public:
     return !valueStream.fail() && !valueStream.bad();
   }
 
-  bool GetPropertyValue(const char *p_cKey, std::string &strValue) const {
+  bool
+  GetPropertyValue(const char * p_cKey, std::string & strValue) const
+  {
     if (m_Osr == NULL)
       return false;
 
@@ -363,13 +422,15 @@ public:
   // x_0 = floor(x_L * D)
   //
   // In this implementation, ITK works with coordinates at the selected level. When L > 0, it becomes challenging
-  // to pick coordinates x_0 that identify x_L exactly. We derive x_0 by upsampling as above. But several values of x_0 will map to x_L.
-  // We need to pick x_L so that it is invariant to an upsample and subsequent downsample. In math we want x_L so that:
+  // to pick coordinates x_0 that identify x_L exactly. We derive x_0 by upsampling as above. But several values of x_0
+  // will map to x_L. We need to pick x_L so that it is invariant to an upsample and subsequent downsample. In math we
+  // want x_L so that:
   //
   // x_L = Downsample(Upsample(x_L)) = floor(floor(x_L * D) / D)
   //
-  // D is known to be a rational number A/B since it is computed by dividing the dimensions of level 0 and level L images.
-  // If A/B is a reduced fraction, we would like to determine x_L so that it is divisible by B. When B divides x_L we have the identity:
+  // D is known to be a rational number A/B since it is computed by dividing the dimensions of level 0 and level L
+  // images. If A/B is a reduced fraction, we would like to determine x_L so that it is divisible by B. When B divides
+  // x_L we have the identity:
   //
   // Upsample(x_L) = D * x_L
   //
@@ -378,15 +439,18 @@ public:
   // Downsample(D * x_L) = x_L
   //
   // Which is what we wanted. Consequently, if dimensions are coprime, the image cannot technically be streamed.
-  // In that case the ImageIORegion would reflect entire level L image. 
+  // In that case the ImageIORegion would reflect entire level L image.
   // This wrapper also supports approximate streaming (ignoring this issue).
-  bool ComputeMinimumStreamableRegionSize(int64_t &i64Width, int64_t &i64Height) const {
+  bool
+  ComputeMinimumStreamableRegionSize(int64_t & i64Width, int64_t & i64Height) const
+  {
     i64Width = i64Height = 0;
 
     if (m_Osr == NULL)
       return false;
 
-    if (m_Level == 0 || m_ApproximateStreaming) { // Nothing to do
+    if (m_Level == 0 || m_ApproximateStreaming)
+    { // Nothing to do
       i64Width = i64Height = 1;
       return true;
     }
@@ -407,7 +471,9 @@ public:
   }
 
   // Compute absolute maximum number of streamable regions
-  int64_t ComputeMaximumNumberOfStreamableRegions() const {
+  int64_t
+  ComputeMaximumNumberOfStreamableRegions() const
+  {
     int64_t i64RegionWidth = 0, i64RegionHeight = 0;
 
     if (!ComputeMinimumStreamableRegionSize(i64RegionWidth, i64RegionHeight))
@@ -425,7 +491,9 @@ public:
   }
 
   // After alignment, what's the maximum number of streamable regions of this size?
-  int64_t ComputeMaximumNumberOfStreamableRegions(int64_t i64X, int64_t i64Y, int64_t i64Width, int64_t i64Height) const {
+  int64_t
+  ComputeMaximumNumberOfStreamableRegions(int64_t i64X, int64_t i64Y, int64_t i64Width, int64_t i64Height) const
+  {
     if (m_Osr == NULL)
       return -1;
 
@@ -439,11 +507,13 @@ public:
     if (!AlignReadRegion(i64X, i64Y, i64Width, i64Height))
       return -1;
 
-    return (i64ImageWidth + i64Width - 1)/i64Width * (i64ImageHeight + i64Height - 1)/i64Height;
+    return (i64ImageWidth + i64Width - 1) / i64Width * (i64ImageHeight + i64Height - 1) / i64Height;
   }
 
   // Align X, Y and region dimensions to be on the grid of points invariant to upsample/downsample
-  bool AlignReadRegion(int64_t &i64X, int64_t &i64Y, int64_t &i64Width, int64_t &i64Height) const {
+  bool
+  AlignReadRegion(int64_t & i64X, int64_t & i64Y, int64_t & i64Width, int64_t & i64Height) const
+  {
     if (m_Osr == NULL)
       return false;
 
@@ -482,10 +552,10 @@ public:
   }
 
 private:
-  openslide_t *m_Osr;
-  int32_t      m_Level;
-  std::string  m_AssociatedImage;
-  bool         m_ApproximateStreaming;
+  openslide_t * m_Osr;
+  int32_t       m_Level;
+  std::string   m_AssociatedImage;
+  bool          m_ApproximateStreaming;
 };
 
 OpenSlideImageIO::OpenSlideImageIO()
@@ -497,7 +567,7 @@ OpenSlideImageIO::OpenSlideImageIO()
   m_OpenSlideWrapper = new OpenSlideWrapper();
 
   this->SetNumberOfDimensions(2); // OpenSlide is 2D.
-  this->SetPixelTypeInfo(&clPixel);  
+  this->SetPixelTypeInfo(&clPixel);
 
   m_Spacing[0] = 1.0;
   m_Spacing[1] = 1.0;
@@ -530,40 +600,52 @@ OpenSlideImageIO::OpenSlideImageIO()
 
 OpenSlideImageIO::~OpenSlideImageIO()
 {
-  if (m_OpenSlideWrapper != NULL) {
+  if (m_OpenSlideWrapper != NULL)
+  {
     delete m_OpenSlideWrapper;
     m_OpenSlideWrapper = NULL;
   }
 }
 
-void OpenSlideImageIO::PrintSelf(std::ostream& os, Indent indent) const {
+void
+OpenSlideImageIO::PrintSelf(std::ostream & os, Indent indent) const
+{
   Superclass::PrintSelf(os, indent);
   os << indent << "Level: " << GetLevel() << '\n';
   os << indent << "Associated Image: " << GetAssociatedImageName() << '\n';
 }
 
-bool OpenSlideImageIO::CanReadFile( const char* filename ) {
-  std::string fname(filename);
-  bool supportedExtension = false;
+bool
+OpenSlideImageIO::CanReadFile(const char * filename)
+{
+  std::string                           fname(filename);
+  bool                                  supportedExtension = false;
   ArrayOfExtensionsType::const_iterator extIt;
 
-  for( extIt = this->GetSupportedReadExtensions().begin(); extIt != this->GetSupportedReadExtensions().end(); ++extIt) {
-    if( fname.rfind( *extIt ) != std::string::npos ) {
+  for (extIt = this->GetSupportedReadExtensions().begin(); extIt != this->GetSupportedReadExtensions().end(); ++extIt)
+  {
+    if (fname.rfind(*extIt) != std::string::npos)
+    {
       supportedExtension = true;
     }
   }
-  if( !supportedExtension ) {
+  if (!supportedExtension)
+  {
     return false;
   }
 
   return OpenSlideWrapper::CanReadFile(filename);
 }
 
-bool OpenSlideImageIO::CanStreamRead() {
+bool
+OpenSlideImageIO::CanStreamRead()
+{
   return m_OpenSlideWrapper != NULL && m_OpenSlideWrapper->CanStreamRead();
 }
 
-void OpenSlideImageIO::ReadImageInformation() {
+void
+OpenSlideImageIO::ReadImageInformation()
+{
   using PixelType = RGBAPixel<unsigned char>;
   PixelType clPixel;
 
@@ -579,19 +661,17 @@ void OpenSlideImageIO::ReadImageInformation() {
   m_Origin[0] = 0.0;
   m_Origin[1] = 0.0;
 
-  if (m_OpenSlideWrapper == NULL) {
-    itkExceptionMacro( "Error OpenSlideImageIO could not open file: "
-                       << this->GetFileName()
-                       << std::endl
-                       << "Reason: NULL OpenSlideWrapper pointer.");
+  if (m_OpenSlideWrapper == NULL)
+  {
+    itkExceptionMacro("Error OpenSlideImageIO could not open file: " << this->GetFileName() << std::endl
+                                                                     << "Reason: NULL OpenSlideWrapper pointer.");
   }
 
-  if (!m_OpenSlideWrapper->Open(this->GetFileName())) {
-    itkExceptionMacro( "Error OpenSlideImageIO could not open file: "
-                       << this->GetFileName()
-                       << std::endl
-                       << "Reason: "
-                       << itksys::SystemTools::GetLastSystemError() );
+  if (!m_OpenSlideWrapper->Open(this->GetFileName()))
+  {
+    itkExceptionMacro("Error OpenSlideImageIO could not open file: " << this->GetFileName() << std::endl
+                                                                     << "Reason: "
+                                                                     << itksys::SystemTools::GetLastSystemError());
     // NOTE: OpenSlide needs to be opened to query API for errors. This is assumed to be related to a system error.
   }
 
@@ -601,29 +681,29 @@ void OpenSlideImageIO::ReadImageInformation() {
 
   {
     int64_t i64Width = 0, i64Height = 0;
-    if (!m_OpenSlideWrapper->GetDimensions(i64Width, i64Height)) {
-      std::string strError = "Unknown";
+    if (!m_OpenSlideWrapper->GetDimensions(i64Width, i64Height))
+    {
+      std::string        strError = "Unknown";
       const char * const p_cError = m_OpenSlideWrapper->GetError();
 
-      if (p_cError != NULL) {
+      if (p_cError != NULL)
+      {
         strError = p_cError;
         m_OpenSlideWrapper->Close(); // Can only safely close this now
       }
 
-      itkExceptionMacro( "Error OpenSlideImageIO could not read dimensions: "
-                         << this->GetFileName()
-                         << std::endl
-                         << "Reason: " << strError );
+      itkExceptionMacro("Error OpenSlideImageIO could not read dimensions: " << this->GetFileName() << std::endl
+                                                                             << "Reason: " << strError);
     }
 
     // i64Width and i64Height are known to be positive
-    if ((uint64_t)i64Width > std::numeric_limits<SizeValueType>::max() || (uint64_t)i64Height > std::numeric_limits<SizeValueType>::max()) {
-      itkExceptionMacro( "Error OpenSlideImageIO image dimensions are too large for SizeValueType: "
-                         << this->GetFileName()
-                         << std::endl
-                         << "Reason: " 
-                         << i64Width << " > " << std::numeric_limits<SizeValueType>::max() 
-                         << " or " << i64Height << " > " << std::numeric_limits<SizeValueType>::max() );
+    if ((uint64_t)i64Width > std::numeric_limits<SizeValueType>::max() ||
+        (uint64_t)i64Height > std::numeric_limits<SizeValueType>::max())
+    {
+      itkExceptionMacro("Error OpenSlideImageIO image dimensions are too large for SizeValueType: "
+                        << this->GetFileName() << std::endl
+                        << "Reason: " << i64Width << " > " << std::numeric_limits<SizeValueType>::max() << " or "
+                        << i64Height << " > " << std::numeric_limits<SizeValueType>::max());
     }
 
     m_Dimensions[0] = (SizeValueType)i64Width;
@@ -634,42 +714,42 @@ void OpenSlideImageIO::ReadImageInformation() {
 }
 
 
-void OpenSlideImageIO::Read( void * buffer)
+void
+OpenSlideImageIO::Read(void * buffer)
 {
   uint32_t * const p_u32Buffer = (uint32_t *)buffer;
 
-  if (m_OpenSlideWrapper == NULL || !m_OpenSlideWrapper->IsOpened()) {
-    itkExceptionMacro( "Error OpenSlideImageIO could not read region: "
-                       << this->GetFileName()
-                       << std::endl
-                       << "Reason: OpenSlide context is not opened." );
+  if (m_OpenSlideWrapper == NULL || !m_OpenSlideWrapper->IsOpened())
+  {
+    itkExceptionMacro("Error OpenSlideImageIO could not read region: " << this->GetFileName() << std::endl
+                                                                       << "Reason: OpenSlide context is not opened.");
   }
 
-  const ImageIORegion clRegionToRead = this->GetIORegion();
-  const ImageIORegion::SizeType clSize = clRegionToRead.GetSize();
+  const ImageIORegion            clRegionToRead = this->GetIORegion();
+  const ImageIORegion::SizeType  clSize = clRegionToRead.GetSize();
   const ImageIORegion::IndexType clStart = clRegionToRead.GetIndex();
 
-  if ( ((uint64_t)clSize[0])*((uint64_t)clSize[1]) > std::numeric_limits<ImageIORegion::SizeValueType>::max() ) {
-    itkExceptionMacro( "Error OpenSlideImageIO could not read region: "
-                       << this->GetFileName()
-                       << std::endl
-                       << "Reason: Requested region size in pixels overflows." );
+  if (((uint64_t)clSize[0]) * ((uint64_t)clSize[1]) > std::numeric_limits<ImageIORegion::SizeValueType>::max())
+  {
+    itkExceptionMacro("Error OpenSlideImageIO could not read region: "
+                      << this->GetFileName() << std::endl
+                      << "Reason: Requested region size in pixels overflows.");
   }
 
-  const char *p_cError = m_OpenSlideWrapper->ReadRegion(p_u32Buffer, clStart[0], clStart[1], clSize[0], clSize[1]);
+  const char * p_cError = m_OpenSlideWrapper->ReadRegion(p_u32Buffer, clStart[0], clStart[1], clSize[0], clSize[1]);
 
-  if (p_cError != NULL) {
+  if (p_cError != NULL)
+  {
     std::string strError = p_cError; // Copy this since Close() may destroy the backing buffer
-    m_OpenSlideWrapper->Close(); // Can only safely close this now
-    itkExceptionMacro( "Error OpenSlideImageIO could not read region: "
-                       << this->GetFileName()
-                       << std::endl
-                       << "Reason: " << strError );
+    m_OpenSlideWrapper->Close();     // Can only safely close this now
+    itkExceptionMacro("Error OpenSlideImageIO could not read region: " << this->GetFileName() << std::endl
+                                                                       << "Reason: " << strError);
   }
 
   // Re-order the bytes (ARGB -> RGBA)
   const int64_t i64TotalSize = clRegionToRead.GetNumberOfPixels();
-  for (int64_t i = 0; i < i64TotalSize; ++i) {
+  for (int64_t i = 0; i < i64TotalSize; ++i)
+  {
     // XXX: Endianness?
     RGBAPixel<unsigned char> clPixel;
     clPixel.SetRed((p_u32Buffer[i] >> 16) & 0xff);
@@ -681,14 +761,15 @@ void OpenSlideImageIO::Read( void * buffer)
   }
 }
 
-bool OpenSlideImageIO::CanWriteFile( const char * /*name*/ )
+bool
+OpenSlideImageIO::CanWriteFile(const char * /*name*/)
 {
   return false;
 }
 
 void
-OpenSlideImageIO
-::WriteImageInformation(void) {
+OpenSlideImageIO ::WriteImageInformation(void)
+{
   // add writing here
 }
 
@@ -697,19 +778,20 @@ OpenSlideImageIO
  *
  */
 void
-OpenSlideImageIO::Write( const void* /*buffer*/) {
-}
+OpenSlideImageIO::Write(const void * /*buffer*/)
+{}
 
 /** Given a requested region, determine what could be the region that we can
  * read from the file. This is called the streamable region, which will be
  * smaller than the LargestPossibleRegion and greater or equal to the
 RequestedRegion */
 ImageIORegion
-OpenSlideImageIO::GenerateStreamableReadRegionFromRequestedRegion( const ImageIORegion & requested ) const {
+OpenSlideImageIO::GenerateStreamableReadRegionFromRequestedRegion(const ImageIORegion & requested) const
+{
   if (m_OpenSlideWrapper == NULL)
     return requested;
 
-  ImageIORegion::SizeType clSize = requested.GetSize();
+  ImageIORegion::SizeType  clSize = requested.GetSize();
   ImageIORegion::IndexType clStart = requested.GetIndex();
 
   int64_t i64X = clStart[0];
@@ -736,21 +818,27 @@ OpenSlideImageIO::GenerateStreamableReadRegionFromRequestedRegion( const ImageIO
 }
 
 /** Get underlying OpenSlide library version */
-std::string OpenSlideImageIO::GetOpenSlideVersion() const {
+std::string
+OpenSlideImageIO::GetOpenSlideVersion() const
+{
   const char * const p_cVersion = OpenSlideWrapper::GetVersion();
   return p_cVersion != NULL ? std::string(p_cVersion) : std::string();
 }
 
 /** Detect the vendor of the current file. */
-std::string OpenSlideImageIO::GetVendor() const {
+std::string
+OpenSlideImageIO::GetVendor() const
+{
   const char * const p_cVendor = OpenSlideWrapper::DetectVendor(this->GetFileName());
   return p_cVendor != NULL ? std::string(p_cVendor) : std::string();
 }
 
 /** Sets the level to read. Level 0 (default) is the highest resolution level.
- * This method overrides any previously selected associated image. 
+ * This method overrides any previously selected associated image.
  * Call ReadImageInformation() again after calling this function. */
-void OpenSlideImageIO::SetLevel(int iLevel) {
+void
+OpenSlideImageIO::SetLevel(int iLevel)
+{
   if (m_OpenSlideWrapper == NULL)
     return;
 
@@ -758,7 +846,9 @@ void OpenSlideImageIO::SetLevel(int iLevel) {
 }
 
 /** Returns the currently selected level. */
-int OpenSlideImageIO::GetLevel() const {
+int
+OpenSlideImageIO::GetLevel() const
+{
   if (m_OpenSlideWrapper == NULL)
     return -1;
 
@@ -766,7 +856,9 @@ int OpenSlideImageIO::GetLevel() const {
 }
 
 /** Returns the number of available levels. */
-int OpenSlideImageIO::GetLevelCount() const {
+int
+OpenSlideImageIO::GetLevelCount() const
+{
   if (m_OpenSlideWrapper == NULL)
     return -1;
 
@@ -776,7 +868,9 @@ int OpenSlideImageIO::GetLevelCount() const {
 /** Sets the associated image to extract.
  * This method overrides any previously selected level.
  * Call ReadImageInformation() again after calling this function. */
-void OpenSlideImageIO::SetAssociatedImageName(const std::string &strName) {
+void
+OpenSlideImageIO::SetAssociatedImageName(const std::string & strName)
+{
   if (m_OpenSlideWrapper == NULL)
     return;
 
@@ -784,7 +878,9 @@ void OpenSlideImageIO::SetAssociatedImageName(const std::string &strName) {
 }
 
 /** Returns the currently selected associated image name (empty string if none). */
-std::string OpenSlideImageIO::GetAssociatedImageName() const {
+std::string
+OpenSlideImageIO::GetAssociatedImageName() const
+{
   if (m_OpenSlideWrapper == NULL)
     return std::string();
 
@@ -792,9 +888,11 @@ std::string OpenSlideImageIO::GetAssociatedImageName() const {
 }
 
 /** Sets the best level to read for the given downsample factor.
- * This method overrides any previously selected associated image. 
+ * This method overrides any previously selected associated image.
  * Call ReadImageInformation() again after calling this function. */
-bool OpenSlideImageIO::SetLevelForDownsampleFactor(double dDownsampleFactor) {
+bool
+OpenSlideImageIO::SetLevelForDownsampleFactor(double dDownsampleFactor)
+{
   if (m_OpenSlideWrapper == NULL)
     return false;
 
@@ -802,7 +900,9 @@ bool OpenSlideImageIO::SetLevelForDownsampleFactor(double dDownsampleFactor) {
 }
 
 /** Returns all associated image names stored in the file. */
-OpenSlideImageIO::AssociatedImageNameContainer OpenSlideImageIO::GetAssociatedImageNames() const {
+OpenSlideImageIO::AssociatedImageNameContainer
+OpenSlideImageIO::GetAssociatedImageNames() const
+{
   if (m_OpenSlideWrapper == NULL)
     return AssociatedImageNameContainer();
 
@@ -810,7 +910,9 @@ OpenSlideImageIO::AssociatedImageNameContainer OpenSlideImageIO::GetAssociatedIm
 }
 
 /** Returns the absolute maximum number of streamable regions (tiles). */
-int64_t OpenSlideImageIO::ComputeMaximumNumberOfStreamableRegions() const {
+int64_t
+OpenSlideImageIO::ComputeMaximumNumberOfStreamableRegions() const
+{
   if (m_OpenSlideWrapper == NULL)
     return -1;
 
@@ -818,12 +920,14 @@ int64_t OpenSlideImageIO::ComputeMaximumNumberOfStreamableRegions() const {
 }
 
 /** Returns the maximum number of streamable regions similar (but >=) to the given region. */
-int64_t OpenSlideImageIO::ComputeMaximumNumberOfStreamableRegions(const ImageIORegion &clRegion) const {
+int64_t
+OpenSlideImageIO::ComputeMaximumNumberOfStreamableRegions(const ImageIORegion & clRegion) const
+{
   if (m_OpenSlideWrapper == NULL)
     return -1;
 
   ImageIORegion::IndexType clStart = clRegion.GetIndex();
-  ImageIORegion::SizeType clSize = clRegion.GetSize();
+  ImageIORegion::SizeType  clSize = clRegion.GetSize();
 
   if (clStart.size() != 2 || clSize.size() != 2)
     return -1;
@@ -832,12 +936,14 @@ int64_t OpenSlideImageIO::ComputeMaximumNumberOfStreamableRegions(const ImageIOR
 }
 
 /** Returns the minimum streamable region. */
-ImageIORegion OpenSlideImageIO::GetMinimumStreamableRegion() const {
+ImageIORegion
+OpenSlideImageIO::GetMinimumStreamableRegion() const
+{
   if (m_OpenSlideWrapper == NULL)
     return ImageIORegion();
 
-  ImageIORegion clRegion;
-  ImageIORegion::SizeType clSize(2);
+  ImageIORegion            clRegion;
+  ImageIORegion::SizeType  clSize(2);
   ImageIORegion::IndexType clIndex(2, 0);
 
   int64_t i64Width = 0, i64Height = 0;
@@ -855,13 +961,17 @@ ImageIORegion OpenSlideImageIO::GetMinimumStreamableRegion() const {
 }
 
 /** Turn on/off approximate streaming. This only affects streaming level images other than level 0. */
-void OpenSlideImageIO::SetApproximateStreaming(bool bApproximateStreaming) {
+void
+OpenSlideImageIO::SetApproximateStreaming(bool bApproximateStreaming)
+{
   if (m_OpenSlideWrapper != NULL)
     m_OpenSlideWrapper->SetApproximateStreaming(bApproximateStreaming);
 }
 
 /** Returns weather approximate streaming is enabled or not. */
-bool OpenSlideImageIO::GetApproximateStreaming() const {
+bool
+OpenSlideImageIO::GetApproximateStreaming() const
+{
   return m_OpenSlideWrapper != NULL && m_OpenSlideWrapper->GetApproximateStreaming();
 }
 

--- a/src/itkOpenSlideImageIOFactory.cxx
+++ b/src/itkOpenSlideImageIOFactory.cxx
@@ -25,24 +25,19 @@ namespace itk
 {
 OpenSlideImageIOFactory::OpenSlideImageIOFactory()
 {
-  this->RegisterOverride("itkImageIOBase",
-                         "itkOpenSlideImageIO",
-                         "OpenSlide Image IO",
-                         1,
-                         CreateObjectFunction<OpenSlideImageIO>::New());
+  this->RegisterOverride(
+    "itkImageIOBase", "itkOpenSlideImageIO", "OpenSlide Image IO", 1, CreateObjectFunction<OpenSlideImageIO>::New());
 }
 
-OpenSlideImageIOFactory::~OpenSlideImageIOFactory()
-{
-}
+OpenSlideImageIOFactory::~OpenSlideImageIOFactory() {}
 
-const char*
+const char *
 OpenSlideImageIOFactory::GetITKSourceVersion() const
 {
   return ITK_SOURCE_VERSION;
 }
 
-const char*
+const char *
 OpenSlideImageIOFactory::GetDescription() const
 {
   return "OpenSlide ImageIO Factory, allows the loading of OpenSlide images into insight";
@@ -53,13 +48,14 @@ OpenSlideImageIOFactory::GetDescription() const
 
 static bool OpenSlideImageIOFactoryHasBeenRegistered;
 
-void IOOpenSlide_EXPORT OpenSlideImageIOFactoryRegister__Private(void)
+void IOOpenSlide_EXPORT
+OpenSlideImageIOFactoryRegister__Private(void)
 {
-  if( ! OpenSlideImageIOFactoryHasBeenRegistered )
-    {
+  if (!OpenSlideImageIOFactoryHasBeenRegistered)
+  {
     OpenSlideImageIOFactoryHasBeenRegistered = true;
     OpenSlideImageIOFactory::RegisterOneFactory();
-    }
+  }
 }
 
 } // end namespace itk

--- a/test/itkOpenSlideImageIOTest.cxx
+++ b/test/itkOpenSlideImageIOTest.cxx
@@ -31,18 +31,22 @@
 
 #define SPECIFIC_IMAGEIO_MODULE_TEST
 
-namespace {
+namespace
+{
 
-bool ParseValue(const char *p_cValue, std::string &strCommand, std::string &strValue) {
+bool
+ParseValue(const char * p_cValue, std::string & strCommand, std::string & strValue)
+{
   strCommand.clear();
   strValue.clear();
 
   if (p_cValue == NULL)
     return false;
 
-  const char *p = strchr(p_cValue, '=');
+  const char * p = strchr(p_cValue, '=');
 
-  if (p == NULL) {
+  if (p == NULL)
+  {
     strCommand = p_cValue;
     return true;
   }
@@ -51,8 +55,8 @@ bool ParseValue(const char *p_cValue, std::string &strCommand, std::string &strV
   if (p == p_cValue)
     return false;
 
-  strCommand.assign(p_cValue, (p-p_cValue));
-  strValue = p+1;
+  strCommand.assign(p_cValue, (p - p_cValue));
+  strValue = p + 1;
 
   return true;
 }
@@ -88,99 +92,119 @@ bool CompressImageFile(const char *p_cFileName) {
 
 } // End anonymous namespace
 
-int itkOpenSlideImageIOTest( int argc, char * argv[] ) {
+int
+itkOpenSlideImageIOTest(int argc, char * argv[])
+{
   using PixelType = itk::RGBAPixel<unsigned char>;
   using ImageType = itk::Image<PixelType, 2>;
   using ReaderIOType = itk::OpenSlideImageIO;
   using ReaderType = itk::ImageFileReader<ImageType>;
   using WriterType = itk::ImageFileWriter<ImageType>;
 
-  if( argc < 3 ) {
+  if (argc < 3)
+  {
     std::cerr << "Usage: " << argv[0] << " inputImage outputImage [command1 command2 ...]\n";
     return EXIT_FAILURE;
   }
 
-  //const char * const p_cArg0 = argv[0];
+  // const char * const p_cArg0 = argv[0];
   const char * const p_cInputImage = argv[1];
   const char * const p_cOutputImage = argv[2];
 
   argc -= 3;
   argv += 3;
 
-  bool bShouldFail = false;
-  bool bUseCompression = false;
-  bool bApproximateStreaming = false;
+  bool         bShouldFail = false;
+  bool         bUseCompression = false;
+  bool         bApproximateStreaming = false;
   unsigned int uiNumStreams = 0; // 0 means no streaming
-  int iLevel = 0;
-  std::string strAssociatedImageName;
-  double dDownsampleFactor = 0.0; // 0 means no down sample
+  int          iLevel = 0;
+  std::string  strAssociatedImageName;
+  double       dDownsampleFactor = 0.0; // 0 means no down sample
 
-  for (int i = 0; i < argc; ++i) {
+  for (int i = 0; i < argc; ++i)
+  {
     std::string strCommand;
     std::string strValue;
 
-    if (!ParseValue(argv[i], strCommand, strValue)) {
+    if (!ParseValue(argv[i], strCommand, strValue))
+    {
       std::cerr << "Error: Could not parse value '" << argv[i] << "'." << std::endl;
       return EXIT_FAILURE;
     }
 
-    if (strCommand == "shouldFail") {
+    if (strCommand == "shouldFail")
+    {
       bShouldFail = true;
     }
-    else if (strCommand == "compress") {
+    else if (strCommand == "compress")
+    {
       bUseCompression = true;
     }
-    else if (strCommand == "approximateStreaming") {
+    else if (strCommand == "approximateStreaming")
+    {
       bApproximateStreaming = true;
     }
-    else if (strCommand == "level") {
-      if (strValue.empty()) {
+    else if (strCommand == "level")
+    {
+      if (strValue.empty())
+      {
         std::cerr << "Error: Expected level parameter." << std::endl;
         return EXIT_FAILURE;
       }
 
-      char *p = NULL;
+      char * p = NULL;
       iLevel = strtol(strValue.c_str(), &p, 10);
-      if (*p != '\0') {
+      if (*p != '\0')
+      {
         std::cerr << "Error: Could not parse level '" << strValue << "'." << std::endl;
         return EXIT_FAILURE;
       }
     }
-    else if (strCommand == "associatedImage") {
-      if (strValue.empty()) {
+    else if (strCommand == "associatedImage")
+    {
+      if (strValue.empty())
+      {
         std::cerr << "Error: Expected associated image name." << std::endl;
         return EXIT_FAILURE;
       }
 
       strAssociatedImageName = strValue;
     }
-    else if (strCommand == "downsample") {
-      if (strValue.empty()) {
+    else if (strCommand == "downsample")
+    {
+      if (strValue.empty())
+      {
         std::cerr << "Error: Expected downsample factor." << std::endl;
         return EXIT_FAILURE;
       }
 
-      char *p = NULL;
+      char * p = NULL;
       dDownsampleFactor = strtod(strValue.c_str(), &p);
-      if (*p != '\0') {
+      if (*p != '\0')
+      {
         std::cerr << "Error: Could not parse downsample factor '" << strValue << "'." << std::endl;
         return EXIT_FAILURE;
       }
     }
-    else if (strCommand == "stream") {
-      if (strValue.empty()) {
+    else if (strCommand == "stream")
+    {
+      if (strValue.empty())
+      {
         std::cerr << "Error: Expected number of streams." << std::endl;
         return EXIT_FAILURE;
       }
 
-      char *p = NULL;
+      char * p = NULL;
       uiNumStreams = strtoul(strValue.c_str(), &p, 10);
-      if (*p != '\0') {
+      if (*p != '\0')
+      {
         std::cerr << "Error: Could not parse number of streams '" << strValue << "'." << std::endl;
         return EXIT_FAILURE;
       }
     }
-    else {
+    else
+    {
       std::cout << "Error: Unknown command '" << argv[i] << "'." << std::endl;
       return EXIT_FAILURE;
     }
@@ -201,8 +225,8 @@ int itkOpenSlideImageIOTest( int argc, char * argv[] ) {
   std::cout << "downsample = " << dDownsampleFactor << std::endl;
 
   ReaderIOType::Pointer p_clImageIO = ReaderIOType::New();
-  ReaderType::Pointer p_clReader = ReaderType::New();
-  WriterType::Pointer p_clWriter = WriterType::New();
+  ReaderType::Pointer   p_clReader = ReaderType::New();
+  WriterType::Pointer   p_clWriter = WriterType::New();
 
   p_clImageIO->SetFileName(p_cInputImage);
 
@@ -212,10 +236,12 @@ int itkOpenSlideImageIOTest( int argc, char * argv[] ) {
   p_clWriter->SetInput(p_clReader->GetOutput());
   p_clWriter->SetFileName(p_cOutputImage);
 
-  try {
+  try
+  {
     p_clImageIO->ReadImageInformation();
   }
-  catch (itk::ExceptionObject &e) {
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << "Error: " << e << std::endl;
     return iFailCode;
   }
@@ -228,15 +254,18 @@ int itkOpenSlideImageIOTest( int argc, char * argv[] ) {
   if (dDownsampleFactor > 0.0 && !p_clImageIO->SetLevelForDownsampleFactor(dDownsampleFactor))
     return iFailCode;
 
-  if (uiNumStreams > 0) {
+  if (uiNumStreams > 0)
+  {
     if (!p_clImageIO->CanStreamRead())
       return iFailCode;
 
     p_clImageIO->UseStreamedReadingOn();
     p_clImageIO->SetApproximateStreaming(bApproximateStreaming);
 
-    itk::ImageIOBase::Pointer p_clWriterIO = itk::ImageIOFactory::CreateImageIO(p_cOutputImage, itk::IOFileModeEnum::WriteMode);
-    if (!p_clWriterIO) {
+    itk::ImageIOBase::Pointer p_clWriterIO =
+      itk::ImageIOFactory::CreateImageIO(p_cOutputImage, itk::IOFileModeEnum::WriteMode);
+    if (!p_clWriterIO)
+    {
       std::cerr << "Error: Could not create ImageIO for output image '" << p_cOutputImage << "'." << std::endl;
       return iFailCode;
     }
@@ -253,16 +282,18 @@ int itkOpenSlideImageIOTest( int argc, char * argv[] ) {
   // XXX: Just so you know, this might disable streaming
   p_clWriter->SetUseCompression(bUseCompression);
 
-  try {
+  try
+  {
     p_clWriter->Update();
   }
-  catch (itk::ExceptionObject &e) {
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << "Error: " << e << std::endl;
     return iFailCode;
   }
 
   // Use this to compress output images when updating tests
-  //CompressImageFile(p_cOutputImage);
+  // CompressImageFile(p_cOutputImage);
 
   return iSuccessCode;
 }

--- a/test/itkOpenSlideTestMetaData.cxx
+++ b/test/itkOpenSlideTestMetaData.cxx
@@ -28,23 +28,27 @@
 
 #define SPECIFIC_IMAGEIO_MODULE_TEST
 
-namespace {
+namespace
+{
 
-class ReplaceStream {
+class ReplaceStream
+{
 public:
-  ReplaceStream(std::ios &stream, const std::ios &newStream)
-  : m_Stream(stream), m_OriginalBuf(stream.rdbuf(newStream.rdbuf())) { }
+  ReplaceStream(std::ios & stream, const std::ios & newStream)
+    : m_Stream(stream)
+    , m_OriginalBuf(stream.rdbuf(newStream.rdbuf()))
+  {}
 
-  ~ReplaceStream() {
-    m_Stream.rdbuf(m_OriginalBuf);
-  }
+  ~ReplaceStream() { m_Stream.rdbuf(m_OriginalBuf); }
 
 private:
-  std::ios               &m_Stream;
+  std::ios &             m_Stream;
   std::streambuf * const m_OriginalBuf;
 };
 
-bool ReadFileStripCR(const char *p_cFileName, std::vector<char> &vBuffer) {
+bool
+ReadFileStripCR(const char * p_cFileName, std::vector<char> & vBuffer)
+{
   vBuffer.clear();
 
   std::ifstream fileStream(p_cFileName);
@@ -61,8 +65,10 @@ bool ReadFileStripCR(const char *p_cFileName, std::vector<char> &vBuffer) {
     return false;
 
   size_t j = 0;
-  for (size_t i = 0; i < vBuffer.size(); ++i) {
-    if (vBuffer[i] != '\r') {
+  for (size_t i = 0; i < vBuffer.size(); ++i)
+  {
+    if (vBuffer[i] != '\r')
+    {
       vBuffer[j] = vBuffer[i];
       ++j;
     }
@@ -75,14 +81,17 @@ bool ReadFileStripCR(const char *p_cFileName, std::vector<char> &vBuffer) {
 
 } // End anonymous namespace
 
-int itkOpenSlideTestMetaData( int argc, char * argv[] ) {
+int
+itkOpenSlideTestMetaData(int argc, char * argv[])
+{
   using ImageIOType = itk::OpenSlideImageIO;
   using PixelType = itk::RGBAPixel<unsigned char>;
   using ImageType = itk::Image<PixelType, 2>;
   using SizeType = ImageType::SizeType;
   using SpacingType = ImageType::SpacingType;
 
-  if (argc < 2 || argc > 4) {
+  if (argc < 2 || argc > 4)
+  {
     std::cerr << "Usage: " << argv[0] << " slideFile [outputLog] [comparisonLog]" << std::endl;
     return EXIT_FAILURE;
   }
@@ -91,12 +100,14 @@ int itkOpenSlideTestMetaData( int argc, char * argv[] ) {
   const char * const p_cOutputLog = argc > 2 ? argv[2] : "stdout";
   const char * const p_cCompareLog = argc > 3 ? argv[3] : NULL;
 
-  std::ofstream logFileStream;
-  std::ostream *p_outStream = &std::cout;
+  std::ofstream  logFileStream;
+  std::ostream * p_outStream = &std::cout;
 
-  if (strcmp(p_cOutputLog, "stdout") != 0) {
+  if (strcmp(p_cOutputLog, "stdout") != 0)
+  {
     logFileStream.open(p_cOutputLog, std::ofstream::out | std::ofstream::trunc);
-    if (!logFileStream) {
+    if (!logFileStream)
+    {
       std::cerr << "Error: Could not open output log '" << p_cOutputLog << "'." << std::endl;
       return EXIT_FAILURE;
     }
@@ -111,15 +122,17 @@ int itkOpenSlideTestMetaData( int argc, char * argv[] ) {
 
   p_clImageIO->SetFileName(p_cSlideFile);
 
-  try {
+  try
+  {
     p_clImageIO->ReadImageInformation();
   }
-  catch (itk::ExceptionObject &e) {
+  catch (itk::ExceptionObject & e)
+  {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;
   }
 
-  const std::string strComponentType = itk::ImageIOBase::GetComponentTypeAsString(p_clImageIO->GetComponentType()); 
+  const std::string strComponentType = itk::ImageIOBase::GetComponentTypeAsString(p_clImageIO->GetComponentType());
   const std::string strPixelType = itk::ImageIOBase::GetPixelTypeAsString(p_clImageIO->GetPixelType());
 
   std::cout << "\nImage Information:\n" << std::endl;
@@ -131,8 +144,10 @@ int itkOpenSlideTestMetaData( int argc, char * argv[] ) {
   // Some sanity checks
 
   // Check dimensions
-  if (p_clImageIO->GetNumberOfDimensions() != ImageType::GetImageDimension()) {
-    std::cerr << "Error: ImageIO should report dimension " << ImageType::GetImageDimension() << " but reports " << p_clImageIO->GetNumberOfDimensions() << '.' << std::endl;
+  if (p_clImageIO->GetNumberOfDimensions() != ImageType::GetImageDimension())
+  {
+    std::cerr << "Error: ImageIO should report dimension " << ImageType::GetImageDimension() << " but reports "
+              << p_clImageIO->GetNumberOfDimensions() << '.' << std::endl;
     return EXIT_FAILURE;
   }
 
@@ -144,32 +159,38 @@ int itkOpenSlideTestMetaData( int argc, char * argv[] ) {
     PixelType clTmpPixel;
     p_clTmpIO->SetPixelTypeInfo(&clTmpPixel);
 
-    const std::string strExpectedComponentType = itk::ImageIOBase::GetComponentTypeAsString(p_clTmpIO->GetComponentType());
+    const std::string strExpectedComponentType =
+      itk::ImageIOBase::GetComponentTypeAsString(p_clTmpIO->GetComponentType());
     const std::string strExpectedPixelType = itk::ImageIOBase::GetPixelTypeAsString(p_clTmpIO->GetPixelType());
 
-    if (strExpectedComponentType != strComponentType) {
-      std::cerr << "Error: ImageIO should report a component type of " << strExpectedComponentType << " but reports " << strComponentType << '.' << std::endl;
+    if (strExpectedComponentType != strComponentType)
+    {
+      std::cerr << "Error: ImageIO should report a component type of " << strExpectedComponentType << " but reports "
+                << strComponentType << '.' << std::endl;
       return EXIT_FAILURE;
     }
 
-    if (strExpectedPixelType != strPixelType) {
-      std::cerr << "Error: ImageIO should report a pixel type of " << strExpectedPixelType << " but reports " << strPixelType << '.' << std::endl;
+    if (strExpectedPixelType != strPixelType)
+    {
+      std::cerr << "Error: ImageIO should report a pixel type of " << strExpectedPixelType << " but reports "
+                << strPixelType << '.' << std::endl;
       return EXIT_FAILURE;
     }
   }
-    
+
   // Sanity checks passed
 
   std::cout << "\nMeta Data:\n" << std::endl;
 
-  itk::MetaDataDictionary &clTags = p_clImageIO->GetMetaDataDictionary();
-  std::vector<std::string> vKeys = clTags.GetKeys();
+  itk::MetaDataDictionary & clTags = p_clImageIO->GetMetaDataDictionary();
+  std::vector<std::string>  vKeys = clTags.GetKeys();
 
   std::cout << "Number of keys: " << vKeys.size() << std::endl;
   std::cout << "Entries:" << std::endl;
-  for (size_t i = 0; i < vKeys.size(); ++i) {
-    const std::string &strKey = vKeys[i];
-    std::string strValue;
+  for (size_t i = 0; i < vKeys.size(); ++i)
+  {
+    const std::string & strKey = vKeys[i];
+    std::string         strValue;
 
     if (itk::ExposeMetaData(clTags, strKey, strValue))
       std::cout << strKey << " = " << strValue << std::endl;
@@ -181,13 +202,16 @@ int itkOpenSlideTestMetaData( int argc, char * argv[] ) {
   std::cout << "Level count: " << iLevelCount << std::endl;
 
   std::cout << "Levels:" << std::endl;
-  for (int iLevel = 0; iLevel < iLevelCount; ++iLevel) {
+  for (int iLevel = 0; iLevel < iLevelCount; ++iLevel)
+  {
     p_clImageIO->SetLevel(iLevel);
 
-    try {
+    try
+    {
       p_clImageIO->ReadImageInformation();
     }
-    catch (itk::ExceptionObject &e) {
+    catch (itk::ExceptionObject & e)
+    {
       std::cerr << "Error: " << e << std::endl;
       return EXIT_FAILURE;
     }
@@ -201,9 +225,10 @@ int itkOpenSlideTestMetaData( int argc, char * argv[] ) {
     clSpacing[1] = p_clImageIO->GetSpacing(1);
 
     const size_t sizeInBytes = p_clImageIO->GetImageSizeInBytes();
-    const int iCurrentLevel = p_clImageIO->GetLevel();
+    const int    iCurrentLevel = p_clImageIO->GetLevel();
 
-    std::cout << "Level " << iCurrentLevel << ": dimensions = " << clSize << ", spacing = " << clSpacing << ", size in bytes = " << sizeInBytes << std::endl;
+    std::cout << "Level " << iCurrentLevel << ": dimensions = " << clSize << ", spacing = " << clSpacing
+              << ", size in bytes = " << sizeInBytes << std::endl;
   }
 
   std::cout << "\nAssociated image information:\n" << std::endl;
@@ -215,13 +240,14 @@ int itkOpenSlideTestMetaData( int argc, char * argv[] ) {
 
   const size_t numWordsPerLine = 3;
 
-  for (size_t i = 0; i < vAssociatedImages.size(); i += numWordsPerLine) {
+  for (size_t i = 0; i < vAssociatedImages.size(); i += numWordsPerLine)
+  {
     const size_t jBegin = i;
     const size_t jEnd = std::min(vAssociatedImages.size(), jBegin + numWordsPerLine);
 
     std::cout << '\'' << vAssociatedImages[jBegin] << '\'';
 
-    for (size_t j = jBegin+1; j < jEnd; ++j)
+    for (size_t j = jBegin + 1; j < jEnd; ++j)
       std::cout << ", '" << vAssociatedImages[j] << '\'';
 
     if (i + numWordsPerLine < vAssociatedImages.size())
@@ -232,15 +258,18 @@ int itkOpenSlideTestMetaData( int argc, char * argv[] ) {
 
   std::cout << "\nAssociated images:" << std::endl;
 
-  for (size_t i = 0; i < vAssociatedImages.size(); ++i) {
-    const std::string &strAssociatedImage = vAssociatedImages[i];
+  for (size_t i = 0; i < vAssociatedImages.size(); ++i)
+  {
+    const std::string & strAssociatedImage = vAssociatedImages[i];
 
     p_clImageIO->SetAssociatedImageName(strAssociatedImage);
 
-    try {
+    try
+    {
       p_clImageIO->ReadImageInformation();
     }
-    catch (itk::ExceptionObject &e) {
+    catch (itk::ExceptionObject & e)
+    {
       std::cerr << "Error: " << e << std::endl;
       return EXIT_FAILURE;
     }
@@ -253,23 +282,27 @@ int itkOpenSlideTestMetaData( int argc, char * argv[] ) {
     clSpacing[0] = p_clImageIO->GetSpacing(0);
     clSpacing[1] = p_clImageIO->GetSpacing(1);
 
-    const size_t sizeInBytes = p_clImageIO->GetImageSizeInBytes();
+    const size_t      sizeInBytes = p_clImageIO->GetImageSizeInBytes();
     const std::string strCurrentAssociatedImage = p_clImageIO->GetAssociatedImageName();
 
-    std::cout << strCurrentAssociatedImage << ": dimensions = " << clSize << ", spacing = " << clSpacing << ", size in bytes = " << sizeInBytes << std::endl;
+    std::cout << strCurrentAssociatedImage << ": dimensions = " << clSize << ", spacing = " << clSpacing
+              << ", size in bytes = " << sizeInBytes << std::endl;
   }
 
-  if (p_cCompareLog != NULL) {
+  if (p_cCompareLog != NULL)
+  {
     logFileStream.close();
 
     std::vector<char> vBuffer1, vBuffer2;
 
-    if (!ReadFileStripCR(p_cOutputLog, vBuffer1)) {
+    if (!ReadFileStripCR(p_cOutputLog, vBuffer1))
+    {
       std::cerr << "Error: Could not read output log file '" << p_cOutputLog << "'." << std::endl;
       return EXIT_FAILURE;
     }
 
-    if (!ReadFileStripCR(p_cCompareLog, vBuffer2)) {
+    if (!ReadFileStripCR(p_cCompareLog, vBuffer2))
+    {
       std::cerr << "Error: Could not read comparison log file '" << p_cCompareLog << "'." << std::endl;
       return EXIT_FAILURE;
     }


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
