### PR TITLE
COMP: Modernize CMake and update CI to v5.4.6 with OpenSlide system packages

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@add-apt-packages-input
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
     with:
       apt-packages: 'libopenslide-dev'
       brew-packages: 'openslide'

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -12,9 +12,13 @@ on:
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.2
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@add-apt-packages-input
+    with:
+      apt-packages: 'libopenslide-dev'
+      brew-packages: 'openslide'
+      os-list: '["ubuntu-22.04", "macos-15-intel", "macos-15"]'
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.2
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
     secrets:
       pypi_password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -18,7 +18,8 @@ jobs:
       brew-packages: 'openslide'
       os-list: '["ubuntu-22.04", "macos-15-intel", "macos-15"]'
 
-  python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
-    secrets:
-      pypi_password: ${{ secrets.pypi_password }}
+  # Python wheel builds are disabled because OpenSlide is an external C
+  # library that is not available in the manylinux Docker containers or
+  # the Windows wheel-build environment.  Re-enable when the Python
+  # workflow gains apt-packages / brew-packages support or the module
+  # bundles its own OpenSlide build.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "itk == 5.4.*",
 ]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,11 +3,6 @@ set(IOOpenSlide_SRCS
   itkOpenSlideImageIO.cxx
   )
 
-include_directories("${IOOpenSlide_SOURCE_DIR}/include")
-include_directories("${CMAKE_CURRENT_BINARY_DIR}")
-include_directories(${OPENSLIDE_INCLUDE_DIRS})
-
-add_library(IOOpenSlide ${IOOpenSlide_SRCS})
+itk_module_add_library(IOOpenSlide ${IOOpenSlide_SRCS})
+target_include_directories(IOOpenSlide PRIVATE ${OPENSLIDE_INCLUDE_DIRS})
 target_link_libraries(IOOpenSlide LINK_PRIVATE ${OPENSLIDE_LIBRARIES})
-itk_module_link_dependencies()
-itk_module_target(IOOpenSlide)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ set(IOOpenSlide_SRCS
   itkOpenSlideImageIO.cxx
   )
 
+include_directories("${IOOpenSlide_SOURCE_DIR}/include")
 include_directories(${OPENSLIDE_INCLUDE_DIRS})
 
 add_library(IOOpenSlide ${IOOpenSlide_SRCS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ set(IOOpenSlide_SRCS
   )
 
 include_directories("${IOOpenSlide_SOURCE_DIR}/include")
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 include_directories(${OPENSLIDE_INCLUDE_DIRS})
 
 add_library(IOOpenSlide ${IOOpenSlide_SRCS})


### PR DESCRIPTION
Re-enable C++ CI by installing OpenSlide via `apt-packages`/`brew-packages` inputs and modernize the CMake build to use `itk_module_add_library`. Disable Python wheel builds (OpenSlide unavailable in manylinux/Windows containers).

<details>
<summary>Changes</summary>

- **Workflow**: Upgrade action ref from `@v5.4.2` → `@v5.4.6`, pass `apt-packages: libopenslide-dev` and `brew-packages: openslide`, restrict C++ OS list to Linux/macOS (no Windows OpenSlide), disable Python wheel workflow.
- **CMake**: Replace legacy `add_library` + `include_directories` + `itk_module_target` with `itk_module_add_library`, which generates the export header and propagates its include directory through target interface properties — fixing `IOOpenSlideExport.h: No such file or directory` in test targets.
- **Python**: Bump minimum to Python 3.10+ in `pyproject.toml`.

</details>

<!--
provenance: claude-code session 2026-04-14
key_facts: C++ builds against ITK v5.4.5 via action @v5.4.6; Python wheels blocked on OpenSlide availability in build containers
related_files: src/CMakeLists.txt:1-8, .github/workflows/build-test-package.yml
post_merge_action: re-enable Python wheels when ITKRemoteModuleBuildTestPackageAction gains apt-packages support for Python workflow
-->